### PR TITLE
Make command prefix configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ A hook method called when press enter on command directly.
 
 ### CommandManager
 
-**constructor(commands)**
+**constructor([prefix, ]commands)**
 
-Construct the `CommandManager` with default `commands`.
+Construct the `CommandManager` with default `commands`. The prefix for commands is configurable through `prefix`, which if not provided defaults to `:`.
 
 **execute(query)**
 

--- a/src/command/history.js
+++ b/src/command/history.js
@@ -24,8 +24,6 @@ class HistoryCommand extends Command {
     }
 
     static record(query, result) {
-        // Ignore the command history
-        if (!query || query.startsWith(":") || !result) return;
         let {content, description} = result;
         description = description
             .replace(/<\/?match>/g, "")

--- a/src/command/manager.js
+++ b/src/command/manager.js
@@ -1,5 +1,16 @@
 class CommandManager {
-    constructor(...commands) {
+    constructor(prefixOrCommand, ...commands) {
+        // The `prefixOrCommand` argument was introduced at a later point, which would break
+        // backwards compatibility. To avoid this breakage the following code checks if the provided
+        // `prefixOrCommand` is indeed a prefix, or if it is the first command and the default
+        // prefix should be used instead.
+        if (typeof prefixOrCommand === 'string') {
+            this.prefix = prefixOrCommand;
+        } else {
+            this.prefix = ":";
+            commands.unshift(prefixOrCommand);
+        }
+
         this.cmds = [];
         commands.forEach(command => this.addCommand(command));
     }
@@ -16,7 +27,7 @@ class CommandManager {
     }
 
     execute(query) {
-        query = query.replace(":", "").trim().toLowerCase();
+        query = query.replace(this.prefix, "").trim().toLowerCase();
         let [name, arg] = query.split(" ");
         let command = this.cmds.find(cmd => cmd.name === name);
         if (command) {
@@ -30,8 +41,8 @@ class CommandManager {
                 .sort((a, b) => a.name.localeCompare(b.name))
                 .map(cmd => {
                     return {
-                        content: `:${cmd.name}`,
-                        description: `${c.match(":" + cmd.name)} - ${c.dim(cmd.description)}`
+                        content: `${this.prefix}${cmd.name}`,
+                        description: `${c.match(this.prefix + cmd.name)} - ${c.dim(cmd.description)}`
                     }
                 });
 
@@ -44,7 +55,7 @@ class CommandManager {
                 ];
             } else {
                 return [
-                    {content: "", description: `No ${c.match(":" + name)} command found, try following commands?`},
+                    {content: "", description: `No ${c.match(this.prefix + name)} command found, try following commands?`},
                     ...list
                 ];
             }
@@ -53,7 +64,7 @@ class CommandManager {
 
     handleCommandEnterEvent(content, disposition) {
         if (content) {
-            content = content.replace(":", "").trim();
+            content = content.replace(this.prefix, "").trim();
             let command = this.cmds.find(cmd => cmd.name === content);
             if (command) {
                 command.onEnter(content, disposition);


### PR DESCRIPTION
Currently the command-prefix is hardcoded to be `:`, which restricts users of this library from using this prefix for other use-cases. This commit makes the command-prefix configurable by introducing a new optional `commandPrefix` argument to the `Omnibox` constructor (while retaining full backwards compatibility).

The command-prefix is stored in a global variable that is accessible and used by the classes in `src/command/`, which allows them to use a prefix that is not `:`.

-----

Also a huge thank you for providing and maintaining this great library! I was able to create the first proof-of-concept of a [search-extension I had in mind](https://github.com/pitkley/aws-search-extension) within just 30-45 minutes, which otherwise would have either taking me many hours, or I would have just not pursued this idea at all.