### PR TITLE
Migrate locaStorage to chrome.storage API

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Bootstrap the omnibox.
 - **config.afterNavigate**: A hook function to after URL navigated. You have the chance to record the history here.
 - **config.onEmptyNavigate**: If the content is a Non-URL which would navigate failed, then fallback to this hook function.
 
+The `onSearch`, `beforeNavigate`, `afterNavigated`, and `onEmptyNavigate` in `Omnibox::boostrap(config)` can be `async` function.
+
 **addPrefixQueryEvent(prefix, event)**
 
 Add prefix query event.
@@ -99,6 +101,8 @@ Add query keyword to prevent cache result.
     searchPriority = 0
 }
 ```
+
+The `onSearch` can be `async` function.
 
 ### Command
 

--- a/manifest.libsonnet
+++ b/manifest.libsonnet
@@ -25,6 +25,7 @@ local content_script = {
       'core/compat.js',
       'core/omnibox.js',
       'core/query-event.js',
+      'core/storage.js',
       'core/command/base.js',
       'core/command/simple.js',
       'core/command/open.js',

--- a/src/command/base.js
+++ b/src/command/base.js
@@ -4,7 +4,7 @@ class Command {
         this.description = description;
     }
 
-    onExecute(arg) {
+    async onExecute(arg) {
     }
 
     // A hook method called when press enter on command directly.

--- a/src/command/history.js
+++ b/src/command/history.js
@@ -12,7 +12,7 @@ class HistoryCommand extends Command {
                 return {
                     content: item.content,
                     description: `${item.query} - ${item.description}`
-                }
+                };
             });
     }
 
@@ -43,7 +43,7 @@ class HistoryCommand extends Command {
             // Limit the search history to the max size.
             history.sort((a, b) => b.time - a.time).splice(maxSize);
         }
-        await storage.setItem("history", JSON.stringify(history));
+        await storage.setItem("history", history);
         return historyItem;
     }
 }

--- a/src/command/history.js
+++ b/src/command/history.js
@@ -3,8 +3,8 @@ class HistoryCommand extends Command {
         super("history", "Show your local search history.", false);
     }
 
-    onExecute(arg) {
-        let history = JSON.parse(localStorage.getItem("history")) || [];
+    async onExecute(arg) {
+        let history = await storage.getItem("history") || [];
         return history
             .filter(item => !arg || item.query.toLowerCase().indexOf(arg) > -1)
             .sort((a, b) => b.time - a.time)
@@ -30,12 +30,12 @@ class HistoryCommand extends Command {
      * @param {number} maxSize The max size that should keep the search history in local storage.
      * @returns the historyItem.
      */
-    static record(query, result, maxSize) {
+    static async record(query, result, maxSize) {
         if (!query || !result) return;
 
         let { content, description } = result;
         description = c.eliminateTags(description);
-        let history = JSON.parse(localStorage.getItem("history")) || [];
+        let history = await storage.getItem("history") || [];
         let historyItem = { query, content, description, time: Date.now() };
         history.push(historyItem);
 
@@ -43,7 +43,7 @@ class HistoryCommand extends Command {
             // Limit the search history to the max size.
             history.sort((a, b) => b.time - a.time).splice(maxSize);
         }
-        localStorage.setItem("history", JSON.stringify(history));
+        await storage.setItem("history", JSON.stringify(history));
         return historyItem;
     }
 }

--- a/src/command/manager.js
+++ b/src/command/manager.js
@@ -26,12 +26,12 @@ class CommandManager {
         }
     }
 
-    execute(query) {
+    async execute(query) {
         query = query.replace(this.prefix, "").trim().toLowerCase();
         let [name, arg] = query.split(" ");
         let command = this.cmds.find(cmd => cmd.name === name);
         if (command) {
-            let result = command.onExecute(arg);
+            let result = await command.onExecute(arg);
             if (!result || result.length < 1) {
                 result = command.onBlankResult(arg);
             }
@@ -50,12 +50,12 @@ class CommandManager {
             if (result.length > 0) {
                 // Filter commands with prefix
                 return [
-                    {content: "", description: `Found following commands, press Tab to select.`},
+                    { content: "", description: `Found following commands, press Tab to select.` },
                     ...result
                 ];
             } else {
                 return [
-                    {content: "", description: `No ${c.match(this.prefix + name)} command found, try following commands?`},
+                    { content: "", description: `No ${c.match(this.prefix + name)} command found, try following commands?` },
                     ...list
                 ];
             }

--- a/src/command/simple.js
+++ b/src/command/simple.js
@@ -7,7 +7,7 @@ class SimpleCommand extends Command {
         this.setIndex(index);
     }
 
-    onExecute(arg) {
+    async onExecute(arg) {
         return this.index
             .filter(item => !arg || item[0].toLowerCase().indexOf(arg) > -1)
             .map(([name, url, description]) => {

--- a/src/omnibox.js
+++ b/src/omnibox.js
@@ -53,7 +53,7 @@ class Omnibox {
         let currentInput;
         let defaultDescription;
 
-        chrome.omnibox.onInputChanged.addListener(async(input, suggestFn) => {
+        chrome.omnibox.onInputChanged.addListener(async (input, suggestFn) => {
             // Set the default suggestion content to input instead null,
             // this could prevent content null bug in onInputEntered().
             this.defaultSuggestionContent = input;
@@ -66,7 +66,7 @@ class Omnibox {
             let { query, page } = this.parse(input);
             // Always perform search if query is a noCachedQuery, then check whether equals to cachedQuery
             if (this.noCacheQueries.has(query) || this.cachedQuery !== query) {
-                results = this.performSearch(query);
+                results = await this.performSearch(query);
                 this.cachedQuery = query;
                 this.cachedResult = results;
             } else {
@@ -99,17 +99,17 @@ class Omnibox {
             suggestFn(results);
         });
 
-        chrome.omnibox.onInputEntered.addListener((content, disposition) => {
+        chrome.omnibox.onInputEntered.addListener(async (content, disposition) => {
             let result;
             // Give beforeNavigate a default function
-            beforeNavigate = beforeNavigate || ((_, s) => s);
+            beforeNavigate = beforeNavigate || (async (_, s) => s);
 
             // A flag indicates whether the url navigate success
             let navigated = false;
             // The first item (aka default suggestion) is special in Chrome extension API,
             // here the content is the user input.
             if (content === currentInput) {
-                content = beforeNavigate(this.cachedQuery, this.defaultSuggestionContent);
+                content = await beforeNavigate(this.cachedQuery, this.defaultSuggestionContent);
                 result = {
                     content,
                     description: defaultDescription,
@@ -122,7 +122,7 @@ class Omnibox {
                 // Store raw content before navigate to find the correct result
                 let rawContent = content;
                 result = results.find(item => item.content === rawContent);
-                content = beforeNavigate(this.cachedQuery, content);
+                content = await beforeNavigate(this.cachedQuery, content);
                 if (URL_PROTOCOLS.test(content)) {
                     Omnibox.navigateToUrl(content, disposition);
                     navigated = true;
@@ -136,9 +136,9 @@ class Omnibox {
             }
 
             if (navigated && afterNavigated) {
-                afterNavigated(this.cachedQuery, result);
+                await afterNavigated(this.cachedQuery, result);
             } else if (onEmptyNavigate) {
-                onEmptyNavigate(content, disposition);
+                await onEmptyNavigate(content, disposition);
             }
 
             this.setDefaultSuggestion(this.defaultSuggestionDescription);
@@ -160,12 +160,12 @@ class Omnibox {
             });
 
         if (matchedEvent) {
-            result = matchedEvent.performSearch(query);
+            result = await matchedEvent.performSearch(query);
             if (matchedEvent.onAppend) {
                 result.push(...matchedEvent.onAppend(query));
             }
         } else {
-            result = this.globalEvent.performSearch(query);
+            result = await this.globalEvent.performSearch(query);
             let defaultSearchEvents = this.queryEvents
                 .filter(event => {
                     // The isDefaultSearch hook method is preferred over defaultSearch property.
@@ -179,7 +179,7 @@ class Omnibox {
                 .sort((a, b) => a.searchPriority - b.searchPriority);
             let defaultSearchAppendixes = [];
             for (let event of defaultSearchEvents) {
-                result.push(...event.performSearch(query));
+                result.push(...await event.performSearch(query));
                 if (event.onAppend) {
                     defaultSearchAppendixes.push(...event.onAppend(query));
                 }

--- a/src/omnibox.js
+++ b/src/omnibox.js
@@ -145,7 +145,7 @@ class Omnibox {
         });
     }
 
-    performSearch(query) {
+    async performSearch(query) {
         let result;
         let matchedEvent = this.queryEvents
             .sort((a, b) => {

--- a/src/query-event.js
+++ b/src/query-event.js
@@ -29,9 +29,9 @@ class QueryEvent {
         this.searchedInput = "";
     }
 
-    performSearch(input) {
+    async performSearch(input) {
         this.searchedInput = input;
-        let result = this.onSearch(input);
+        let result = await this.onSearch(input);
         return result.map(item => {
             // FIXME: item could be a non-object type, maybe we need Typescript to fix this...
             item['event'] = this;

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,10 +1,12 @@
-// Mimic localStorage API with chrome.storage
+// Mimic localStorage API with chrome.storage.
+// See also: https://developer.chrome.com/docs/extensions/reference/storage/
 const storage = {
     getAllItems: () => new Promise(resolve => {
         chrome.storage.local.get(null, (result) => {
             resolve(result);
         });
     }),
+    // Gets one or more items from storage.
     getItem: key => new Promise(resolve => {
         chrome.storage.local.get(key, (result) => {
             if (result) {
@@ -14,13 +16,15 @@ const storage = {
             }
         });
     }),
+    // Set signle key-value pair item.
     setItem: (key, val) => new Promise(resolve => {
         chrome.storage.local.set({
             [key]: val
         }, resolve)
     }),
-    removeItems: keys => new Promise(resolve => {
-        chrome.storage.local.remove(keys);
+    // Removes one or more items from storage.
+    removeItem: key => new Promise(resolve => {
+        chrome.storage.local.remove(key);
         resolve()
     }),
 };

--- a/src/storage.js
+++ b/src/storage.js
@@ -2,9 +2,7 @@
 // See also: https://developer.chrome.com/docs/extensions/reference/storage/
 const storage = {
     getAllItems: () => new Promise(resolve => {
-        chrome.storage.local.get(null, (result) => {
-            resolve(result);
-        });
+        chrome.storage.local.get(null, resolve);
     }),
     // Gets one or more items from storage.
     getItem: key => new Promise(resolve => {
@@ -24,8 +22,7 @@ const storage = {
     }),
     // Removes one or more items from storage.
     removeItem: key => new Promise(resolve => {
-        chrome.storage.local.remove(key);
-        resolve()
+        chrome.storage.local.remove(key, resolve);
     }),
 };
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -33,7 +33,7 @@ async function migrateLocalStorage(key) {
             // Some plain text isn't JSON parsable.
             value = JSON.parse(value);
         } catch (e) {
-            console.error(e);
+            console.log(`can't parse ${value} as JSON: ${e}`);
         }
         await storage.setItem(key, value);
     }

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,7 +1,14 @@
 // Mimic localStorage API with chrome.storage
 const storage = {
     getAllItems: () => storageGet(null),
-    getItem: async key => (await storageGet(key))[key],
+    getItem: async key => {
+        let value = await storageGet(key);
+        if (value && key in value) {
+            return value[key];
+        } else {
+            return null;
+        }
+    },
     setItem: (key, val) => new Promise(resolve => {
         chrome.storage.local.set({
             [key]: val

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,14 +1,19 @@
 // Mimic localStorage API with chrome.storage
 const storage = {
-    getAllItems: () => storageGet(null),
-    getItem: async key => {
-        let value = await storageGet(key);
-        if (value && key in value) {
-            return value[key];
-        } else {
-            return null;
-        }
-    },
+    getAllItems: () => new Promise(resolve => {
+        chrome.storage.local.get(null, (result) => {
+            resolve(result);
+        });
+    }),
+    getItem: key => new Promise(resolve => {
+        chrome.storage.local.get(key, (result) => {
+            if (result) {
+                resolve(result[key]);
+            } else {
+                resolve(null);
+            }
+        });
+    }),
     setItem: (key, val) => new Promise(resolve => {
         chrome.storage.local.set({
             [key]: val
@@ -19,14 +24,6 @@ const storage = {
         resolve()
     }),
 };
-
-function storageGet(key) {
-    return new Promise(resolve => {
-        chrome.storage.local.get(key, (result) => {
-            resolve(result[key]);
-        });
-    });
-}
 
 // A helper function to migrate localStorage to chrome.storage API.
 async function migrateLocalStorage(key) {

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,9 +1,30 @@
 // Mimic localStorage API with chrome.storage
 const storage = {
-    getAllItems: () => chrome.storage.local.get(null),
-    getItem: async key => (await chrome.storage.local.get(key))[key],
-    setItem: (key, val) => chrome.storage.local.set({
-        [key]: val
+    getAllItems: () => storageGet(null),
+    getItem: async key => (await storageGet(key))[key],
+    setItem: (key, val) => new Promise(resolve => {
+        chrome.storage.local.set({
+            [key]: val
+        }, resolve)
     }),
-    removeItems: keys => chrome.storage.local.remove(keys),
+    removeItems: keys => new Promise(resolve => {
+        chrome.storage.local.remove(keys);
+        resolve()
+    }),
 };
+
+function storageGet(key) {
+    return new Promise(resolve => {
+        chrome.storage.local.get(key, (result) => {
+            resolve(result[key]);
+        });
+    });
+}
+
+// A helper function to migrate localStorage to chrome.storage API.
+async function migrateLocalStorage(key) {
+    let value = localStorage.getItem(key);
+    if (value) {
+        await storage.setItem(key, JSON.parse(value));
+    }
+}

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,9 @@
+// Mimic localStorage API with chrome.storage
+const storage = {
+    getAllItems: () => chrome.storage.local.get(null),
+    getItem: async key => (await chrome.storage.local.get(key))[key],
+    setItem: (key, val) => chrome.storage.local.set({
+        [key]: val
+    }),
+    removeItems: keys => chrome.storage.local.remove(keys),
+};

--- a/src/storage.js
+++ b/src/storage.js
@@ -29,6 +29,12 @@ const storage = {
 async function migrateLocalStorage(key) {
     let value = localStorage.getItem(key);
     if (value) {
-        await storage.setItem(key, JSON.parse(value));
+        try {
+            // Some plain text isn't JSON parsable.
+            value = JSON.parse(value);
+        } catch (e) {
+            console.error(e);
+        }
+        await storage.setItem(key, value);
     }
 }


### PR DESCRIPTION
This migration is required because Chrome Manifest V3 changes the background script to the service worker,
however, the service worker doesn't support localStorage API. Therefore, we should migrate those data to
`chrome.storage` before we upgrade to Manifest V3. Otherwise, we can't do such a migration, because we
cannot access localStorage API in the service worker anymore.