### PR TITLE
Set browserType to firefox for all gecko-based browsers

### DIFF
--- a/src/compat.js
+++ b/src/compat.js
@@ -10,7 +10,7 @@ class Compat {
 
     browserType() {
         let userAgent = navigator.userAgent.toLowerCase();
-        if (userAgent.indexOf("firefox") !== -1)
+        if (userAgent.indexOf("gecko") !== -1)
             return "firefox";
         if (userAgent.indexOf("edg") !== -1)
             return "edge";


### PR DESCRIPTION
For example, Librewolf's UA is `Mozilla/5.0 (X11; Linux x86_64; rv:110.0) Gecko/20100101 LibreWolf/110.0`.

This means the extension used to break on Librewolf (as well as other Firefox forks).