### PR TITLE
Add `addOptionalHostPermissions`

### DIFF
--- a/manifest_v3.libsonnet
+++ b/manifest_v3.libsonnet
@@ -36,6 +36,9 @@ local resource = {
     addHostPermissions(permission):: self + {
       host_permissions+: if std.isArray(permission) then permission else [permission],
     },
+    addOptionalHostPermissions(permission):: self + {
+      optional_host_permissions+: if std.isArray(permission) then permission else [permission],
+    },
     addAction(popup, title):: self + {
       _action+: {
         default_icon: it._icons,

--- a/test_v3.jsonnet
+++ b/test_v3.jsonnet
@@ -15,6 +15,7 @@ manifest.new(
 .addPermissions(['storage', 'unlimitedStorage'])
 .addHostPermissions('https://github.com/huhu/search-extension-core/*')
 .addHostPermissions(['https://docs.rs/*', 'https://crates.io/*'])
+.addOptionalHostPermissions(['file:///*'])
 .addWebAccessibleResources(resources = ['test.js'])
 .addContentScript(
   matches=['google.com', 'github.com'],


### PR DESCRIPTION
In order to solve huhu/rust-search-extension#263, we need to make the "Allow access to file URLs" setting show. I suggest we use [this solution](https://groups.google.com/a/chromium.org/g/chromium-extensions/c/ZtCvVISQU54/m/Qv_wCnnUAQAJ):

> I ended up adding "optional_host_permissions": [ "file:///*" ]
> This way the "Allow access to file URLs" is shown, navigation works, but I don't actually get read permission.

The next part of the fix is at huhu/rust-search-extension#275. Thank you for your attention.